### PR TITLE
Addresses issue 155, use modern compilers

### DIFF
--- a/deal.II-toolchain/platforms/supported/centos7.platform
+++ b/deal.II-toolchain/platforms/supported/centos7.platform
@@ -5,6 +5,7 @@
 #
 # sudo yum install patch svn git wget \
 # @development-tools gcc-c++ cmake \
+# centos-release-scl devtoolset-9 \
 # openmpi openmpi-devel \
 # patch \
 # libtool libtool-ltdl libtool-ltdl-devel \
@@ -12,6 +13,8 @@
 # blas blas-devel lapack lapack-devel \
 # doxygen graphviz graphviz-devel qt-devel
 # 
+# Be sure to switch to the recent compilers with
+# $ scl enable devtoolset-9 bash 
 # Please load the 'openmpi' compiler with
 # $  module load mpi/openmpi-x86_64
 # and then set the compiler enviroment variables to


### PR DESCRIPTION
By default CentOS7 uses very old compilers, this installs and uses modern compilers from the CentOS default repositories without needing to build a DIY toolchain