### PR TITLE
Addresses issue 154, default cmake is old

### DIFF
--- a/deal.II-toolchain/platforms/supported/centos7.platform
+++ b/deal.II-toolchain/platforms/supported/centos7.platform
@@ -27,5 +27,5 @@ TRILINOS_PARMETIS_CONFOPTS="\
 
 #
 # Define the additional packages for this platform.
-#PACKAGES="once:cmake ${PACKAGES}"
+PACKAGES="once:cmake ${PACKAGES}"
 


### PR DESCRIPTION
The default cmake in CentOS 7  is cmake 2.x, cmake 3.x is available in the repos, but it is invoked with `cmake3` this change tells candi to build its own cmake instead of using the system provided one (if it exists)